### PR TITLE
conf: Add the start command to launch dev-server with production mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
-    "lint": "vue-cli-service lint"
+    "lint": "vue-cli-service lint",
+    "start": "vue-cli-service serve --mode=production"
   },
   "dependencies": {
     "core-js": "^3.6.5",


### PR DESCRIPTION
This patch adds the 'start' command that launches dev-server with production mode.

Signed-off-by: Wook Song <wook16.song@samsung.com>